### PR TITLE
Improve readability with fallback dark background

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -33,10 +33,12 @@
 
       body {
         margin: 0;
-        background: linear-gradient(135deg, 
-          rgb(var(--tropical-deep-green)) 0%, 
-          rgb(var(--tropical-stone) / 0.9) 50%, 
+        background: linear-gradient(135deg,
+          rgb(var(--tropical-deep-green)) 0%,
+          rgb(var(--tropical-stone) / 0.9) 50%,
           rgb(var(--tropical-ocean-deep)) 100%);
+        /* Fallback solid color for readability */
+        background-color: #121212;
         background-attachment: fixed;
         color: rgb(var(--tropical-mist));
         font-family: 'Outfit', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -51,10 +51,12 @@
   body {
     @apply font-sans antialiased;
     font-family: 'Outfit', sans-serif;
-    background: linear-gradient(135deg, 
-      rgb(var(--tropical-deep-green)) 0%, 
-      rgb(var(--tropical-stone) / 0.9) 50%, 
+    background: linear-gradient(135deg,
+      rgb(var(--tropical-deep-green)) 0%,
+      rgb(var(--tropical-stone) / 0.9) 50%,
       rgb(var(--tropical-ocean-deep)) 100%);
+    /* Fallback solid color for readability */
+    background-color: #121212;
     background-attachment: fixed;
     color: rgb(var(--tropical-mist));
     position: relative;


### PR DESCRIPTION
## Summary
- add solid dark background for improved readability

## Testing
- `npm run check` *(fails: ServerOptions type mismatch)*

------
https://chatgpt.com/codex/tasks/task_b_686028fb834c833088e08865f8e66717