### PR TITLE
Align UI components with design spec

### DIFF
--- a/client/src/components/EventsCard.tsx
+++ b/client/src/components/EventsCard.tsx
@@ -79,7 +79,7 @@ export const EventsCard: React.FC = () => {
                 </div>
               </div>
               <div className="flex-1 min-w-0">
-                <h3 className="text-sm font-medium text-primary">{event.title}</h3>
+                <h3 className="text-sm font-medium text-primary line-clamp-2">{event.title}</h3>
                 <p className="text-xs text-secondary mb-1">
                   {event.venue} • {event.time}
                 </p>

--- a/client/src/components/MoviesCard.tsx
+++ b/client/src/components/MoviesCard.tsx
@@ -78,7 +78,7 @@ export const MoviesCard: React.FC = () => {
                 </p>
                 <div className="flex flex-wrap gap-1">
                   {movie.times.map((time, timeIndex) => (
-                    <span key={timeIndex} className="px-2 py-1 bg-slate-700 rounded text-xs text-primary">
+                    <span key={timeIndex} className="px-2 h-6 inline-flex items-center bg-slate-700 rounded text-xs text-primary">
                       {time}
                     </span>
                   ))}

--- a/client/src/components/TideCard.tsx
+++ b/client/src/components/TideCard.tsx
@@ -93,7 +93,7 @@ export const TideCard: React.FC = () => {
       <div className="space-y-3">
         <h3 className="text-sm font-medium text-secondary mb-3">Next Tides</h3>
         {tides.upcoming.slice(0, 4).map((tide, index) => (
-          <div key={index} className="glass rounded-2xl p-4 hover:bg-[rgb(var(--tropical-stone)/0.2)] transition-all duration-300">
+          <div key={index} className="glass rounded-2xl p-4 min-h-12 hover:bg-[rgb(var(--tropical-stone)/0.2)] transition-all duration-300">
             <div className="flex items-center justify-between">
               <div className="flex items-center space-x-3">
                 <div className={`w-10 h-10 rounded-xl flex items-center justify-center ${

--- a/client/src/components/WeatherCard.tsx
+++ b/client/src/components/WeatherCard.tsx
@@ -52,7 +52,7 @@ export const WeatherCard: React.FC = () => {
           <div className="relative">
             <div className="w-12 h-12 rounded-2xl flex items-center justify-center overflow-hidden">
               <div className="absolute inset-0 bg-gradient-to-br from-[rgb(var(--tropical-ocean))] to-[rgb(var(--tropical-ocean-light))]"></div>
-              <WeatherIcon className="w-6 h-6 text-white relative z-10" />
+              <WeatherIcon className="w-8 h-8 text-white relative z-10" />
             </div>
           </div>
           <div>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -211,6 +211,13 @@
     min-width: 48px;
   }
 
+  .line-clamp-2 {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    overflow: hidden;
+  }
+
   .animate-fade-in {
     animation: fadeIn 0.5s ease-in-out;
   }


### PR DESCRIPTION
## Summary
- adjust weather icon to 32px
- clamp event card titles to two lines
- set showtime pill height
- enforce minimum height for tide items
- add reusable `.line-clamp-2` utility

## Testing
- `npm run check` *(fails: type errors)*

------
https://chatgpt.com/codex/tasks/task_b_68602b5ce18c8330be995394db20ec70