### PR TITLE
Add surf forecasting card

### DIFF
--- a/client/public/wave.svg
+++ b/client/public/wave.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill="none" stroke="currentColor" stroke-width="1">
+  <path d="M0 50c10-5 20-5 30 0s20 5 30 0 20-5 30 0 20 5 30 0"/>
+</svg>

--- a/client/src/components/cards/SurfCard.tsx
+++ b/client/src/components/cards/SurfCard.tsx
@@ -1,0 +1,71 @@
+import { ArrowUpRight, Waves } from "lucide-react";
+import { Card, CardHeader, CardTitle, CardContent, CardDescription } from "@/components/ui/card";
+import { useSurf } from "@/hooks/useSurf";
+import { cn } from "@/lib/utils";
+
+/** Utility to turn compass degrees into N, NE, E… – quick & light */
+const headings = ["N","NE","E","SE","S","SW","W","NW"] as const;
+const toHeading = (deg:number) => headings[Math.round(deg / 45) % 8];
+
+/** Quick colour ramp for the surf “rating” chip */
+const heightColor = (ft:number) => {
+  if (ft < 2) return "bg-tropical-ocean-light";
+  if (ft < 4) return "bg-tropical-ocean";
+  if (ft < 6) return "bg-tropical-ocean-deep";
+  return "bg-red-500";
+};
+
+type Props = { breakName?: string; lat?: number; lng?: number };
+
+export default function SurfCard(props: Props) {
+  const { data, isLoading, error } = useSurf({
+    name: props.breakName ?? "Ala Moana Bowls",
+    lat: props.lat ?? 21.276,
+    lng: props.lng ?? -157.822,
+  });
+
+  if (error) return <Card><CardContent>❌ Surf data error.</CardContent></Card>;
+  if (isLoading || !data) return <Card className="animate-pulse h-40" />;
+
+  const { waveHeight, swellDir, swellPeriod, windSpeed, windDir } = data as any;
+
+  return (
+    <Card className="relative overflow-hidden shadow-tropical
+        bg-gradient-to-br from-tropical-ocean-light/30 via-white/0 to-white/0
+        after:absolute after:-top-40 after:-left-40 after:w-[200%] after:h-[200%]
+        after:bg-[url('/wave.svg')] after:bg-[length:400px_400px] after:opacity-5 after:animate-float-pattern">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-lg flex items-center gap-2">
+          <Waves className="w-5 h-5" /> Surf · {props.breakName ?? "Bowls"}
+        </CardTitle>
+        <CardDescription className="text-xs">
+          Updated {new Date((data as any).time).toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" })}
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent className="flex items-end justify-between">
+        <span
+          className={cn(
+            "font-display text-5xl font-semibold leading-none tracking-tight pr-1",
+            heightColor((data as any).waveHeight)
+          )}
+        >
+          {(data as any).waveHeight?.toFixed(1)}<span className="text-2xl">ft</span>
+        </span>
+
+        <div className="text-right text-sm">
+          <div className="flex items-center justify-end gap-1">
+            <ArrowUpRight
+              style={{ transform: `rotate(${swellDir}deg)` }}
+              className="w-4 h-4 text-tropical-stone"
+            />
+            Swell {toHeading(swellDir)} / {Math.round((data as any).swellPeriod)} s
+          </div>
+          <div className="flex items-center justify-end gap-1">
+            🌬 {windSpeed.toFixed(0)} kn {toHeading(windDir)}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/src/hooks/useSurf.ts
+++ b/client/src/hooks/useSurf.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+
+/**
+ * HNL default coords point at Ala Moana Bowls – adjust as needed.
+ */
+const DEFAULT_BREAK = { name: "Ala Moana Bowls", lat: 21.276, lng: -157.822 };
+
+export function useSurf(breakInfo = DEFAULT_BREAK) {
+  const { lat, lng } = breakInfo;
+
+  return useQuery({
+    queryKey: [`/api/surf?lat=${lat}&lng=${lng}`], // queryKey[0] is the endpoint string used by your default queryFn
+    staleTime: 30 * 60 * 1000, // half-hour cache
+  });
+}

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Waves, RefreshCw, WifiOff, Palmtree } from 'lucide-react';
 import { WeatherCard } from '../components/WeatherCard';
+import SurfCard from '@/components/cards/SurfCard';
 import { TideCard } from '../components/TideCard';
 import { MoviesCard } from '../components/MoviesCard';
 import { EventsCard } from '../components/EventsCard';
@@ -126,6 +127,9 @@ export default function Home() {
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 lg:gap-8">
           <div className="tropical-card p-6 animate-fade-in" style={{ animationDelay: '0.1s' }}>
             <WeatherCard />
+          </div>
+          <div className="tropical-card p-6 animate-fade-in" style={{ animationDelay: '0.15s' }}>
+            <SurfCard />
           </div>
           <div className="tropical-card p-6 animate-fade-in" style={{ animationDelay: '0.2s' }}>
             <TideCard />

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,5 +1,6 @@
 import express, { type Request, Response, NextFunction } from "express";
 import { registerRoutes } from "./routes";
+import { surfRouter } from "./routes/surf.js";
 import { setupVite, serveStatic, log } from "./vite";
 
 const app = express();
@@ -38,6 +39,8 @@ app.use((req, res, next) => {
 
 (async () => {
   const server = await registerRoutes(app);
+
+  app.use("/api/surf", surfRouter);
 
   app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
     const status = err.status || err.statusCode || 500;

--- a/server/routes/surf.ts
+++ b/server/routes/surf.ts
@@ -1,0 +1,38 @@
+import express from "express";
+
+export const surfRouter = express.Router();
+
+/**
+ * GET /api/surf?lat=21.276&lng=-157.822
+ * Returns the *next* hour of marine data from Open-Meteo,
+ * converted to feet for Hawai‘i.
+ */
+surfRouter.get("/", async (req, res) => {
+  const { lat, lng } = req.query;
+  if (!lat || !lng) {
+    return res.status(400).json({ error: "lat & lng are required" });
+  }
+
+  try {
+    // We only need a two-hour slice so the JSON stays tiny
+    const url = `https://marine-api.open-meteo.com/v1/marine?latitude=${lat}&longitude=${lng}&hourly=wave_height,swell_wave_height,swell_wave_direction,swell_wave_period,wind_speed_10m,wind_direction_10m&length_unit=ft&wind_speed_unit=kn`;
+
+    const response = await fetch(url);
+    if (!response.ok) throw new Error(`Open-Meteo ${response.status}`);
+
+    const data = await response.json();
+    // Pick the first hour (index 0).  API always starts at the present hour.
+    res.json({
+      time: data.hourly.time[0],
+      waveHeight: data.hourly.wave_height[0],
+      swellHeight: data.hourly.swell_wave_height[0],
+      swellDir: data.hourly.swell_wave_direction[0],
+      swellPeriod: data.hourly.swell_wave_period[0],
+      windSpeed: data.hourly.wind_speed_10m[0],
+      windDir: data.hourly.wind_direction_10m[0],
+    });
+  } catch (err) {
+    console.error(err);
+    res.status(502).json({ error: "Surf data unavailable" });
+  }
+});

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -4,7 +4,6 @@ import path from "path";
 import { createServer as createViteServer, createLogger } from "vite";
 import { type Server } from "http";
 import viteConfig from "../vite.config";
-import { nanoid } from "nanoid";
 
 const viteLogger = createLogger();
 
@@ -23,7 +22,7 @@ export async function setupVite(app: Express, server: Server) {
   const serverOptions = {
     middlewareMode: true,
     hmr: { server },
-    allowedHosts: true,
+    allowedHosts: true as const,
   };
 
   const vite = await createViteServer({
@@ -56,7 +55,7 @@ export async function setupVite(app: Express, server: Server) {
       let template = await fs.promises.readFile(clientTemplate, "utf-8");
       template = template.replace(
         `src="/src/main.tsx"`,
-        `src="/src/main.tsx?v=${nanoid()}"`,
+        `src="/src/main.tsx?v=${crypto.randomUUID()}"`,
       );
       const page = await vite.transformIndexHtml(url, template);
       res.status(200).set({ "Content-Type": "text/html" }).end(page);


### PR DESCRIPTION
## Summary
- create Surf API route and mount in server
- add SurfCard component with surf data hook
- use React Query hook for surf info
- inject SurfCard into homepage
- bundle wave pattern asset
- replace nanoid usage with crypto UUID

## Testing
- `pnpm check`
- `pnpm dev` *(fails: none)*

------
https://chatgpt.com/codex/tasks/task_b_686034e7b67c8330aa7ab6f3c0cc6fb3