### PR TITLE
Apply tropical stone as primary text color

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -55,6 +55,7 @@
   /* Semantic Color Mappings - Design Specification Exact */
   --background: rgb(var(--tropical-deep-green)); /* Background: Deep green */
   --foreground: rgb(var(--tropical-mist)); /* Text Primary: Mist (#F5F3F0) */
+  --text-primary: var(--tropical-stone); /* Primary text color */
   --muted: rgb(var(--tropical-sage) / 0.5);
   --muted-foreground: rgb(var(--tropical-sand)); /* Text Secondary: Sand (#EADDCA) */
   --popover: rgb(var(--tropical-stone) / 0.98); /* Surface: Stone with varying opacity (80-98%) */
@@ -90,7 +91,7 @@
     background: linear-gradient(180deg, var(--tropical-mist) 0%, var(--tropical-sand) 100%) !important;
     /* Design Specification: Lighter mist to sand gradient - Force Applied */
     background-attachment: fixed;
-    color: rgb(245, 243, 240) !important; /* Text Primary: Mist (#F5F3F0) */
+    color: var(--text-primary) !important;
     position: relative;
   }
 
@@ -164,9 +165,9 @@
   }
 
   /* Clear typography hierarchy - Enhanced Contrast */
-  .text-primary { 
-    color: rgb(var(--tropical-mist)); 
-    opacity: 1; 
+  .text-primary {
+    color: var(--text-primary);
+    opacity: 1;
     text-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
   }
   
@@ -583,8 +584,8 @@ body,
 .text-foreground,
 .text-primary,
 h1, h2, h3, h4, h5, h6,
-p, span, div {
-  color: #F5F3F0 !important; /* Mist */
+body, p, li {
+  color: var(--text-primary) !important;
 }
 
 .text-muted-foreground,


### PR DESCRIPTION
## Summary
- set `--text-primary` to `var(--tropical-stone)`
- use `var(--text-primary)` for body and text classes
- ensure body, p and li inherit the primary text color

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_b_686044ce7cc483309ee298fd4aad5ee9